### PR TITLE
Infra Update `v6`: Modules Injection, More Provenance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Tommy needs to review changes to infra
+/.github/ @CodeGat
+

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,9 +10,12 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v5
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v6
     with:
       model: ${{ vars.NAME }}
+      spack-manifest-schema-version: 1-0-7
+      config-versions-schema-version: 3-0-0
+      config-packages-schema-version: 1-0-0
     permissions:
       contents: write
       # This is due to the entrypoint also handling `on.pull_request` events

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,23 +24,24 @@ jobs:
   pr-ci:
     name: CI
     if: >-
-      (github.event_name == 'pull_request' && github.event.action != 'closed') ||
-      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!redeploy'))
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v5
+      (github.event_name == 'pull_request' && github.event.action != 'closed') || (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!redeploy'))
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v6
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
       pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
+      spack-manifest-schema-version: 1-0-7
+      config-versions-schema-version: 3-0-0
+      config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
       contents: write
       statuses: write
     secrets: inherit
-
   pr-comment:
     name: Comment
     if: github.event_name == 'issue_comment'
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v5
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v6
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
@@ -48,11 +49,10 @@ jobs:
       pull-requests: write
       contents: write
     secrets: inherit
-
   pr-closed:
     name: Closed
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v5
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v6
     with:
       root-sbd: ${{ vars.NAME }} # or something else, if different from vars.NAME
     secrets: inherit

--- a/config/packages.json
+++ b/config/packages.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/packages/1-0-0.json",
+  "provenance": [
+    "roms"
+  ],
+  "injection": [
+    "openmpi"
+  ]
+}

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,34 +5,33 @@
 spack:
   # TODO: This section is used primarily to provide variations to a model based on deployment target. Delete if not required.
   # definitions:
-    # This is the root spack bundle that contains the model
-    # - ROOT_PACKAGE:
-    #   - MODEL@git.GIT_REF=SPACK_VERSION
+  # This is the root spack bundle that contains the model
+  # - ROOT_PACKAGE:
+  #   - MODEL@git.GIT_REF=SPACK_VERSION
 
-    # Mutually-exclusive Compiler and Target definitions (assumes DEPLOYMENT_TARGET set)
-    # - when: env['DEPLOYMENT_TARGET'] == 'Gadi'
-    #   compiler_target: ['%intel@19.0.5.281 target=x86_64_v4']
-    # More mutually-exclusive definitions can be made...
-    # Default
-    # - when: "'DEPLOYMENT_TARGET' not in env"
-    #   compiler_targets: ['intel@2021.2.0 target=x86_64']
+  # Mutually-exclusive Compiler and Target definitions (assumes DEPLOYMENT_TARGET set)
+  # - when: env['DEPLOYMENT_TARGET'] == 'Gadi'
+  #   compiler_target: ['%intel@19.0.5.281 target=x86_64_v4']
+  # More mutually-exclusive definitions can be made...
+  # Default
+  # - when: "'DEPLOYMENT_TARGET' not in env"
+  #   compiler_targets: ['intel@2021.2.0 target=x86_64']
 
-    # This is where the single definitions of ROOT_PACKAGE and compiler/target are
-    # matrixed together to form a single spec: MODEL@git.GIT_REF=SPACK_VERSION %intel@2021.2.0 target=x86_64
-    # - ROOT_SPEC:
-    #   - matrix:
-    #     - [$ROOT_PACKAGE]
-    #     - [$%compiler_target]
-
+  # This is where the single definitions of ROOT_PACKAGE and compiler/target are
+  # matrixed together to form a single spec: MODEL@git.GIT_REF=SPACK_VERSION %intel@2021.2.0 target=x86_64
+  # - ROOT_SPEC:
+  #   - matrix:
+  #     - [$ROOT_PACKAGE]
+  #     - [$%compiler_target]
   specs:
-    # The root Spack Bundle Recipe (SBR) for the model and overall version of
-    # the deployment:
-    # TODO: Replace the MODEL, GIT_REF and SPACK_VERSION, if there is
-    #       only one deployment target
-    # - MODEL@git.GIT_REF=SPACK_VERSION
-    # Alternatively, if there are multiple deployment targets that require
-    # different compilers/variants, use the above definitions section and:
-    # - $ROOT_SPEC
+  # The root Spack Bundle Recipe (SBR) for the model and overall version of
+  # the deployment:
+  # TODO: Replace the MODEL, GIT_REF and SPACK_VERSION, if there is
+  #       only one deployment target
+  # - MODEL@git.GIT_REF=SPACK_VERSION
+  # Alternatively, if there are multiple deployment targets that require
+  # different compilers/variants, use the above definitions section and:
+  # - $ROOT_SPEC
   packages:
     # Specification of dependency versions and variants. CI/CD requires that
     # the first element of the require is only a version:
@@ -43,38 +42,10 @@ spack:
 
     # Specifications that apply to all packages
     all:
-      # TODO: Specify compiler/targets for all packages
-      # require:
-      #   - '%intel@2021.10.0'
-      #   - 'target=x86_64'
+    # TODO: Specify compiler/targets for all packages
+    # require:
+    #   - '%intel@2021.10.0'
+    #   - 'target=x86_64'
   view: true
   concretizer:
     unify: true
-  modules:
-    default:
-      tcl:
-        include:
-          # TODO: Add MODEL and PACKAGEs that will have a corresponding module
-          # - MODEL
-          # - PACKAGE1
-          # - PACKAGE2
-        projections:
-          # These projection GIT_REFs must be the same as the
-          # `spack.packages.*.require[0]` ref but without the `@git.`
-          # and without the '=SPACK_VERSION', if there is one.
-          #
-          # For a MODEL, an example projection is `{name}/2024.10.0`.
-          # For a PACKAGE where `require` @git.GIT_REF=SPACK_VERSION is
-          # `@git.2024.04.21=access-esm1.5`, the projection becomes
-          # `{name}/2024.04.21-{hash:7}`.
-          # TODO: Add explicit projections for modules that will be found with
-          #       `module load`.
-          # MODEL: '{name}/VERSION'
-          # PACKAGE1: '{name}/VERSION1-{hash:7}'
-          # PACKAGE2: '{name}/VERSION2-{hash:7}'
-  # config:
-  #   overridden spack configurations, if needed
-  # mirrors:
-  #   overridden spack package tarball directories, if needed
-  # repos:
-  #   overridden repo sources, if needed


### PR DESCRIPTION
References issue ACCESS-NRI/build-cd#311 and PR ACCESS-NRI/build-cd#306

> [!IMPORTANT]
> This PR is a major update to the deployment infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

## Background

This update is a bundle of major-level changes.

The main new features include:

* **`spack.modules` Section is Now Injected At Build Time**: A long-standing pain point for developers was having to update spec and dependency versions in multiple places at once. Now, this is injected at build time. Users can still specify their own projections and includes as required (with the others injected automatically to get a working build), but this makes it much simpler. We recommend removing the `spack.modules` section entirely - it has been done for this PR, but can be reverted if required. 

* **Special Packages Now Specified In `config/packages.json`**: Rather than a relatively obscure `vars.BUILD_DB_PACKAGES`, we now specify special packages for inclusion in the release provenance database in the `config/packages.json` file (specifically the `.provenance` field). Furthermore, we can include modulefiles for additional packages from the `.injection` field. 

* **All Schema Now Specified In Workflow Entrypoint Inputs**: Schema versions for manifests and files under `config/` were kept track on in `vars` - this was obscure, repo-scoped and untracked. It is now a **new, required** input to the CI workflow (`inputs.*-schema-version`), meaning users can pick schema versions for their files at the PR level, and it is now tracked by git. We can also pick a particular manifest schema to test against via the new, optional `inputs.spack-manifest-schema-path` - useful for manifests that are less restrictive, like the ones for software deployment rather than model deployment. 

* **`.github/CODEOWNERS` File Sets Required Reviewers**: Currently only requires that changes to the `.github` folder require review from @CodeGat. This file can be changed as required by the MDR in this PR, or later. There was talk of adding CODEOWNERS for various `spack.yaml`s. 

## Prerequisites for Merging

- [x] Update `build-cd` entrypoints (this PR!)
- [x] Add CODEOWNERS file (also this PR!)
- [x] Add `config/packages.json` file (again in this PR!)
- [x] Remove `spack.modules` section from `spack.yaml`, revert if there are breaking changes (yep, in this PR)
- [x] Delete `vars.*_SCHEMA_VERSION` and `vars.BUILD_DB_PACKAGE` only when all non-draft PRs have rebased onto this PR
- [x] Verify that modules are injected as appropriate for this MDR
