### PR TITLE
Infra Update `v8`: `spack v1` Support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,11 +10,11 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v7
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ vars.NAME }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       contents: write

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -8,12 +8,11 @@ jobs:
   redeploy:
     name: Redeploy
     if: startsWith(github.event.comment.body, '!redeploy') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      pr: ${{ github.event.issue.number }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
@@ -23,7 +22,7 @@ jobs:
   bump:
     name: Bump
     if: startsWith(github.event.comment.body, '!bump') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v8
     with:
       model: ${{ vars.NAME }}
     permissions:
@@ -33,7 +32,7 @@ jobs:
   configs:
     name: Configs
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v8
     with:
       model: ${{ vars.NAME }}
       auto-configs-pr-schema-version: 1-0-0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,14 @@ on:
 jobs:
   pr-ci:
     name: CI
-    if: >-
-      github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    if: github.event.action != 'closed'
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
       pr: ${{ github.event.pull_request.number }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
@@ -37,7 +36,7 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
     with:
       root-sbd: ${{ vars.NAME }} # or something else, if different from vars.NAME
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      # root-sbd: if different from vars.NAME
-      pr: ${{ github.event.pull_request.number }}
       spack-manifest-schema-version: 2-0-0
       config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
@@ -37,6 +35,4 @@ jobs:
     name: Closed
     if: github.event.action == 'closed'
     uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
-    with:
-      root-sbd: ${{ vars.NAME }} # or something else, if different from vars.NAME
     secrets: inherit

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
-  "spack": "1.0",
+  "spack": "1.1",
   "access-spack-packages": "2025.08.001"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
-    "spack": "0.22",
-    "spack-packages": "2025.08.001"
+  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
+  "spack": "1.0",
+  "access-spack-packages": "2025.08.001"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2025.08.001"
+  "access-spack-packages": "2026.02.002"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,6 +15,7 @@ spack:
     ancoms-roms:
       require:
       - '@4.2'
+      - '+mpi'
       - roms_application='upwelling'
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
       - roms_application='upwelling'
     openmpi:
       require:
-      - '@4.1.4'
+      - '@4.1.5'
     netcdf-c:
       require:
       - '@4.7.3'

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [coastri-roms]
-  - _version: [2025.06.000]
+  - _version: [2026.02.000]
   specs:
   - coastri-roms
   packages:
@@ -26,13 +26,13 @@ spack:
     # Compilers
     c:
       require:
-      - intel-oneapi-compilers-classic@2021.8.0
+      - intel-oneapi-compilers-classic@2021.10.0
     cxx:
       require:
-      - intel-oneapi-compilers-classic@2021.8.0
+      - intel-oneapi-compilers-classic@2021.10.0
     fortran:
       require:
-      - intel-oneapi-compilers-classic@2021.8.0
+      - intel-oneapi-compilers-classic@2021.10.0
 
     # Specifications that apply to all packages
     all:

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,7 @@ spack:
     # the first element of the require is only a version
     ancoms-roms:
       require:
-      - '@4.2' 
+      - '@4.2'
       - roms_application='upwelling'
     openmpi:
       require:
@@ -22,11 +22,14 @@ spack:
     netcdf-c:
       require:
       - '@4.7.3'
-
+    # Compilers
+    intel-oneapi-compilers:
+      require:
+      - '@2021.8.0'
     # Specifications that apply to all packages
     all:
       require:
-      - '%intel@2021.8.0'
+      - '%access_intel'
       - 'target=x86_64'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,14 +22,21 @@ spack:
     netcdf-c:
       require:
       - '@4.7.3'
+
     # Compilers
-    intel-oneapi-compilers:
+    c:
       require:
-      - '@2021.8.0'
+      - intel-oneapi-compilers-classic@2021.8.0
+    cxx:
+      require:
+      - intel-oneapi-compilers-classic@2021.8.0
+    fortran:
+      require:
+      - intel-oneapi-compilers-classic@2021.8.0
+
     # Specifications that apply to all packages
     all:
-      require:
-      - '%access_intel'
+      prefer:
       - 'target=x86_64'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,26 +4,26 @@
 # configuration settings.
 spack:
   specs:
-    - coastri-roms@git.2025.06.000
+  - coastri-roms@git.2025.06.000
   packages:
     # Specification of dependency versions and variants. CI/CD requires that
     # the first element of the require is only a version
     ancoms-roms:
       require:
-        - '@4.2' 
-        - roms_application='upwelling'
+      - '@4.2' 
+      - roms_application='upwelling'
     openmpi:
       require:
-        - '@4.1.4'
+      - '@4.1.4'
     netcdf-c:
       require:
-        - '@4.7.3'
+      - '@4.7.3'
 
     # Specifications that apply to all packages
     all:
       require:
-        - '%intel@2021.8.0'
-        - 'target=x86_64'
+      - '%intel@2021.8.0'
+      - 'target=x86_64'
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -3,8 +3,12 @@
 # It describes a set of packages to be installed, along with
 # configuration settings.
 spack:
+  definitions:
+  # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
+  - _name: [coastri-roms]
+  - _version: [2025.06.000]
   specs:
-  - coastri-roms@git.2025.06.000
+  - coastri-roms
   packages:
     # Specification of dependency versions and variants. CI/CD requires that
     # the first element of the require is only a version


### PR DESCRIPTION
References issue ACCESS-NRI/build-cd#313 and PR ACCESS-NRI/build-cd#326
References rollout issue ACCESS-NRI/build-cd#328
References project https://github.com/orgs/ACCESS-NRI/projects/37

> [!IMPORTANT]
> This PR is a major update to the deployment infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

> [!IMPORTANT]
> This major version change marks the end of major infrastructure updates for deployments to `spack < 1.0`.
> If you want to deploy to instances of `spack < 1.0`, you must use `build-cd < v8`.
> If you want to deploy to instances of `spack >= 1.0`, you must use `build-cd >= v8`.

## Background

We are moving on up to `spack v1`! This update to spack contains many bug fixes, optimisations and new features that can be incorporated into `build-cd`.

This update also contains changes that make `spack v0.X` incompatible with this `build-cd v8` update - the most prominent one being the splitting of spacks core codebase from it's builtin spack-packages repo. This means that for provenance, one to keep track of both `builtin` spack-packages and our own, renamed `access-spack-packages`. `build-cd` will centrally control the version of builtin `spack-packages` for a given instance, and `config/versions.json`s `spack-packages` key is renamed to `access-spack-packages`.

As noted earlier, this major version of `build-cd` can only support `spack v1`, due to `spack v1`-specific commands in the infrastructure. If you still want to deploy to `spack v0.X`, you will need to change `build-cd` to `v7`, and update the `config/versions.json` file/`spack.yaml`.

## Features

* **Support for spack v1**: We're moving to a new, non-beta version of spack! It contains bug fixes, features and optimisations over the old version.

## Prerequisites for Merging

- [x] Update `build-cd` entrypoints (this PR!)
- [x] Update `config/versions.json` with new inputs (also this PR!)
- [x] Validate compiler additions to the spack manifest (this PR, too!)
- [x] Test and Verify Model built with `spack v1`


---
:rocket: The latest prerelease `coastri-roms/pr6-8` at 53aa13d37de5ecb21a846ef973f3eae54ac5d4cb is here: https://github.com/ACCESS-NRI/CoastRI-ROMS/pull/6#issuecomment-3987627059 :rocket:







