### PR TITLE
Update to intel@2021.13.1

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -27,13 +27,13 @@ spack:
     # Compilers
     c:
       require:
-      - intel-oneapi-compilers-classic@2021.10.0
+      - intel-oneapi-compilers-classic@2021.13.1
     cxx:
       require:
-      - intel-oneapi-compilers-classic@2021.10.0
+      - intel-oneapi-compilers-classic@2021.13.1
     fortran:
       require:
-      - intel-oneapi-compilers-classic@2021.10.0
+      - intel-oneapi-compilers-classic@2021.13.1
 
     # Specifications that apply to all packages
     all:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [coastri-roms]
-  - _version: [2026.02.000]
+  - _version: [2026.03.000]
   specs:
   - coastri-roms
   packages:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,13 +27,13 @@ spack:
     # Compilers
     c:
       require:
-      - intel-oneapi-compilers-classic@2021.13.1
+      - intel-oneapi-compilers@2025.2.0
     cxx:
       require:
-      - intel-oneapi-compilers-classic@2021.13.1
+      - intel-oneapi-compilers@2025.2.0
     fortran:
       require:
-      - intel-oneapi-compilers-classic@2021.13.1
+      - intel-oneapi-compilers@2025.2.0
 
     # Specifications that apply to all packages
     all:


### PR DESCRIPTION
## Background

The previous spack v1 migration (in #6) built but didn't run properly. 

We had updated the compiler from `intel@2021.8.0` to `intel@2021.10.0` because `intel@2021.8.0` was removed from our compiler list for `spack v1`. 

This PR looks for a suitable replacement compiler - which we've found in `oneapi@2025.2.0`!


---
:rocket: The latest prerelease `coastri-roms/pr7-2` at e9e537c7c23dda4ea53e2aca3eb1c4676f3c8b19 is here: https://github.com/ACCESS-NRI/CoastRI-ROMS/pull/7#issuecomment-3988488689 :rocket:

