### PR TITLE
Recreated: Update Post Spack v1 Compiler

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -27,13 +27,13 @@ spack:
     # Compilers
     c:
       require:
-      - intel-oneapi-compilers-classic@2021.10.0
+      - intel-oneapi-compilers-classic@2021.13.1
     cxx:
       require:
-      - intel-oneapi-compilers-classic@2021.10.0
+      - intel-oneapi-compilers-classic@2021.13.1
     fortran:
       require:
-      - intel-oneapi-compilers-classic@2021.10.0
+      - intel-oneapi-compilers-classic@2021.13.1
 
     # Specifications that apply to all packages
     all:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [coastri-roms]
-  - _version: [2026.02.000]
+  - _version: [2026.03.000]
   specs:
   - coastri-roms
   packages:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,13 +27,13 @@ spack:
     # Compilers
     c:
       require:
-      - intel-oneapi-compilers-classic@2021.13.1
+      - intel-oneapi-compilers@2025.2.0
     cxx:
       require:
-      - intel-oneapi-compilers-classic@2021.13.1
+      - intel-oneapi-compilers@2025.2.0
     fortran:
       require:
-      - intel-oneapi-compilers-classic@2021.13.1
+      - intel-oneapi-compilers@2025.2.0
 
     # Specifications that apply to all packages
     all:


### PR DESCRIPTION
Recreation of #7 after I'd accidentally forgot to remove the `[no ci]` from the commit message (which would mean that there would be no release!

## The PR

- **Update to intel@2021.13.1**
- **Use oneapi@2025.2.0**
- **[no ci] Update version to 2026.03.000**
